### PR TITLE
Add utf-8 codec for unicode characters and bump dependencies 

### DIFF
--- a/django_sns_view/__init__.py
+++ b/django_sns_view/__init__.py
@@ -1,2 +1,2 @@
 # -*- coding: utf-8 -*-
-__version__ = '0.1.2'  # pragma: no cover
+__version__ = '0.1.2-sl.1'  # pragma: no cover

--- a/django_sns_view/utils.py
+++ b/django_sns_view/utils.py
@@ -1,7 +1,6 @@
 from base64 import b64decode
 import logging
 import re
-import six
 import requests
 import pem
 
@@ -100,7 +99,7 @@ def verify_notification(payload):
     """
     pemfile = get_pemfile(payload['SigningCertURL'])
     cert = crypto.load_certificate(crypto.FILETYPE_PEM, pemfile)
-    signature = b64decode(six.b(payload['Signature']))
+    signature = b64decode(payload['Signature'].encode('utf-8'))
 
     if payload['Type'] == "Notification":
         if payload.get('Subject'):
@@ -112,7 +111,7 @@ def verify_notification(payload):
 
     try:
         crypto.verify(
-            cert, signature, six.b(hash_format.format(**payload)), 'sha1')
+            cert, signature, hash_format.format(**payload).encode('utf-8'), 'sha1')
     except crypto.Error as e:
         logger.error('Verification of signature raised an Error: %s', e)
         return False

--- a/tox.ini
+++ b/tox.ini
@@ -1,10 +1,9 @@
 [tox]
-envlist = {py27}-django{18,111}
+envlist = {py38}-django{31}
 [testenv]
 basepython =
-    py27: python2.7
+    py38: python3.8
 deps =
-    django18: django<1.8.99
-    django111: django<1.11.99
+    django31: django<=3.1.2
     -rtest_requirements.txt
 commands = python manage.py test


### PR DESCRIPTION
`six.b` encodes with a latin-1 codec, which causes open events with non-ascii subjects to crash.