### PR TITLE
Verify that subscription request comes from known AWS account

### DIFF
--- a/django_sns_view/__init__.py
+++ b/django_sns_view/__init__.py
@@ -1,2 +1,2 @@
 # -*- coding: utf-8 -*-
-__version__ = '0.1.2-sl.1'  # pragma: no cover
+__version__ = '0.1.3'  # pragma: no cover

--- a/django_sns_view/tests/test_settings.py
+++ b/django_sns_view/tests/test_settings.py
@@ -38,15 +38,6 @@ TEMPLATES = [{
 }]
 
 EXTERNAL_APPS = [
-    'django.contrib.admin',
-    'django.contrib.admindocs',
-    'django.contrib.auth',
-    'django.contrib.contenttypes',
-    'django.contrib.messages',
-    'django.contrib.sessions',
-    'django.contrib.staticfiles',
-    'django.contrib.sitemaps',
-    'django.contrib.sites',
 ]
 
 INTERNAL_APPS = [
@@ -64,10 +55,10 @@ MIDDLEWARE_CLASSES = [
 
 SECRET_KEY = 'foobar'
 
-TEST_RUNNER = 'django_nose.NoseTestSuiteRunner'
+#TEST_RUNNER = 'django_nose.NoseTestSuiteRunner'
 
-NOSE_ARGS = [
-    '--with-xunit',
-    '--nologcapture',
-    '--cover-package=django_sns_view',
-]
+# NOSE_ARGS = [
+#     '--with-xunit',
+#     '--nologcapture',
+#     '--cover-package=django_sns_view',
+# ]

--- a/django_sns_view/tests/urls.py
+++ b/django_sns_view/tests/urls.py
@@ -1,0 +1,3 @@
+
+
+urlpatterns = []

--- a/django_sns_view/views.py
+++ b/django_sns_view/views.py
@@ -51,7 +51,8 @@ class SNSEndpoint(View):
         """
         if hasattr(settings, 'AWS_ACCOUNT_ID'):
             arn = payload['TopicArn'].split(':')[4]
-            if  arn == settings.AWS_ACCOUNT_ID:
+            print(arn)
+            if arn == settings.AWS_ACCOUNT_ID:
                 return True
             else:
                 logger.warning("Recieved subscription confirmation from account %s, but only accepting from account %s", arn, settings.AWS_ACCOUNT_ID)

--- a/test_requirements.txt
+++ b/test_requirements.txt
@@ -1,7 +1,5 @@
 tox==2.9.1
-nose
 requests
-django-nose
 coverage
 mock
 pyopenssl>=0.13.1


### PR DESCRIPTION
Currently, this package validates that subscription requests are signed by AWS, but this allows any account on AWS to create a topic and start sending messages to an endpoint.

This is a potential security problem — if an attacker can discover the URL for an endpoint, they can create their own topics that write to them, and the subscription and subsequent messages will be accepted.

This PR creates a way to deny subscription requests that aren't coming from a known AWS account, configurable in the Django settings. It also introduces an easy way to customize this behavior, by overriding the `should_confirm_subscription` method.

If there's interest in merging this PR, I'd be happy to write some documentation for it.

Note that I had to remove the `nose-tests` dependency — that library is no longer maintained, and `./manage.py test` works out of the box now.